### PR TITLE
Fix types

### DIFF
--- a/source/interfaces/Method.ts
+++ b/source/interfaces/Method.ts
@@ -1,9 +1,7 @@
 import MethodOverride from './MethodOverride';
 import MethodProperties from './MethodProperties';
-import Search from './Search';
 
 export default interface Method extends MethodProperties {
   type: 'get' | 'post' | 'put' | 'delete' | 'patch';
-  search: Search;
   overrides?: Array<MethodOverride>;
 }

--- a/source/interfaces/MethodOverride.ts
+++ b/source/interfaces/MethodOverride.ts
@@ -2,5 +2,5 @@ import MethodProperties from './MethodProperties';
 
 export default interface MethodOverride extends MethodProperties {
   name: string;
-  selected: boolean;
+  selected?: boolean;
 }

--- a/source/interfaces/Proxy.ts
+++ b/source/interfaces/Proxy.ts
@@ -1,5 +1,4 @@
 export default interface Proxy {
   name: string;
   host: string;
-  proxy: Function;
 }

--- a/source/interfaces/ProxyManager.ts
+++ b/source/interfaces/ProxyManager.ts
@@ -1,5 +1,7 @@
+import ProxyResult from './ProxyResult';
+
 export default interface ProxyManager {
   getAll: Function;
-  getCurrent: Function;
+  getCurrent: () => ProxyResult | null;
   toggleCurrent: Function;
 }

--- a/source/interfaces/ProxyResult.ts
+++ b/source/interfaces/ProxyResult.ts
@@ -1,0 +1,5 @@
+import Proxy from './Proxy'
+
+export default interface ProxyResult extends Proxy {
+  proxy: Function,
+}

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -1,6 +1,7 @@
 import Proxy from './interfaces/Proxy';
 import ProxyManager from './interfaces/ProxyManager';
 import ProxyProperties from './interfaces/ProxyProperties';
+import ProxyResult from "./interfaces/ProxyResult";
 import httpProxyMiddleware from 'http-proxy-middleware';
 
 /**
@@ -10,7 +11,7 @@ import httpProxyMiddleware from 'http-proxy-middleware';
  *
  * @return {Proxy} The proxy with the proxy middleware.
  */
-function createProxyMiddleware(proxy: ProxyProperties): Proxy {
+function createProxyMiddleware(proxy: ProxyProperties): ProxyResult {
   const { name, host } = proxy;
 
   return {
@@ -52,7 +53,7 @@ export function createProxyManager(
      *
      * @return {Proxy} The current proxy.
      */
-    getCurrent(): Proxy | null {
+    getCurrent(): ProxyResult | null {
       if (currentProxyIndex !== null) {
         return proxyMiddlewares[currentProxyIndex];
       }


### PR DESCRIPTION
While I was using `the-fake-backend` I saw some "errors" when creating new routes:

#### Proxy
<img width="862" alt="Screen Shot 2020-04-09 at 10 01 29" src="https://user-images.githubusercontent.com/2437673/78899624-077da780-7a4c-11ea-93b1-afd2e3e870f2.png">

This `proxy` function is only used internally so, I create `ProxyResult` interface.
Commit: https://github.com/rhberro/the-fake-backend/commit/fc152f96c469f9d261c1e44e33ce44848113147a

#### Search
<img width="642" alt="Screen Shot 2020-04-09 at 10 13 34" src="https://user-images.githubusercontent.com/2437673/78899636-0ba9c500-7a4c-11ea-81f1-b1373945e655.png">

This `search` is optional and is already declared in `MethodProperties`.
Commit: https://github.com/rhberro/the-fake-backend/commit/3b95ab7940e38e0c749d7a684ae5480e4d098ad7

#### Overrides
<img width="554" alt="Screen Shot 2020-04-09 at 10 17 45" src="https://user-images.githubusercontent.com/2437673/78899638-0c425b80-7a4c-11ea-85f7-ed53540714bb.png">

The `selected` should be optional.
Commit: https://github.com/rhberro/the-fake-backend/commit/046ace5b0a670ac183624e5b21a2034ebe367431
