### PR TITLE
Add route path fixture fallback

### DIFF
--- a/source/files.ts
+++ b/source/files.ts
@@ -80,7 +80,7 @@ export function readFixturePathSync(path: string): any {
  *
  * @return {any} The file content.
  */
-export function readFixtureSync(path: string, fallbackPath: string): any {
+export function readFixtureSync(path: string, fallbackPath?: string): any {
   const extension = extname(path);
 
   try {

--- a/source/files.ts
+++ b/source/files.ts
@@ -76,19 +76,32 @@ export function readFixturePathSync(path: string): any {
  * Read a fixture file using the extension when available or by reading the whole directory.
  *
  * @param {string} path The file path.
+ * @param {string} fallbackPath The fallback file path.
  *
  * @return {any} The file content.
  */
-export function readFixtureSync(path: string): any {
+export function readFixtureSync(path: string, fallbackPath: string): any {
   const extension = extname(path);
 
   try {
     return extension ? readFixtureFileSync(path) : readFixturePathSync(path);
   } catch (error) {
-    console.error(
-      'You probably forgot to create the fixture file.',
-      path,
-      error
-    );
+    if (fallbackPath) {
+      try {
+        return readFixturePathSync(fallbackPath);
+      } catch (fallbackError) {
+        console.error(
+          'You probably forgot to create the fallback fixture file',
+          fallbackPath,
+          fallbackError
+        );
+      }
+    } else {
+      console.error(
+        'You probably forgot to create the fixture file.',
+        path,
+        error
+      );
+    }
   }
 }

--- a/source/server.ts
+++ b/source/server.ts
@@ -60,6 +60,7 @@ export function createServer(options: ServerOptions): Server {
    */
   function getContent(
     method: Method,
+    routePath: string,
     req: express.Request,
     res: express.Response
   ) {
@@ -67,7 +68,10 @@ export function createServer(options: ServerOptions): Server {
     const { path } = req;
 
     const resolvedData = typeof data === 'function' ? data(req) : data;
-    let content = resolvedData || readFixtureSync(file || path);
+    let content =
+      resolvedData ||
+      readFixtureSync(file || path) ||
+      readFixtureSync(routePath);
 
     if (search) {
       content = createSearchableResponse(req, res, content, method);
@@ -110,6 +114,7 @@ export function createServer(options: ServerOptions): Server {
    */
   function createMethodResponse(
     method: Method,
+    routePath: string,
     req: express.Request,
     res: express.Response
   ): void {
@@ -122,7 +127,7 @@ export function createServer(options: ServerOptions): Server {
     }
 
     if (isSuccessfulStatusCode(code)) {
-      const content = getContent(parsedMethod, req, res);
+      const content = getContent(parsedMethod, routePath, req, res);
 
       sendContent(res, code, content, parsedMethod.headers, parsedMethod.delay);
     } else {
@@ -140,7 +145,7 @@ export function createServer(options: ServerOptions): Server {
     const { path } = route;
     const { type } = method;
 
-    const response = createMethodResponse.bind(null, method);
+    const response = createMethodResponse.bind(null, method, path);
 
     expressServer[type](path, response);
   }

--- a/source/server.ts
+++ b/source/server.ts
@@ -68,10 +68,7 @@ export function createServer(options: ServerOptions): Server {
     const { path } = req;
 
     const resolvedData = typeof data === 'function' ? data(req) : data;
-    let content =
-      resolvedData ||
-      readFixtureSync(file || path) ||
-      readFixtureSync(routePath);
+    let content = resolvedData || readFixtureSync(file || path, routePath);
 
     if (search) {
       content = createSearchableResponse(req, res, content, method);


### PR DESCRIPTION
This PR closes #26.

As commented on the issue, it provides the simpler solution: when the entire request path doesn't match a fixture, the entire route path will be used as the fixture.