### PR TITLE
[Bugfix] Fix global overrides

### DIFF
--- a/source/server.spec.ts
+++ b/source/server.spec.ts
@@ -1,5 +1,5 @@
 import { createServer } from './server';
-import { Server, RouteProperties } from './interfaces';
+import { Server, RouteProperties, Route } from './interfaces';
 import { MethodType } from './enums';
 
 jest.mock('../source/ui', () => ({
@@ -11,12 +11,18 @@ jest.mock('../source/ui', () => ({
   }),
 }));
 
-jest.mock('../source/routes', () => ({
-  RouteManager: () => ({
-    getAll: jest.fn(() => []),
-    setAll: jest.fn(),
-  }),
-}));
+jest.mock('../source/routes', () => {
+  let routes: Route[] = [];
+
+  return {
+    RouteManager: () => ({
+      getAll: jest.fn(() => routes),
+      setAll: jest.fn((newRoutes) => {
+        routes = newRoutes;
+      }),
+    }),
+  };
+});
 
 jest.mock('../source/input', () => ({
   InputManager: () => ({

--- a/source/server.ts
+++ b/source/server.ts
@@ -217,7 +217,7 @@ export function createServer(options = {} as ServerOptions): Server {
      */
     routes(routes): void {
       routeManager.setAll(routes);
-      routes.map(createRoute);
+      routeManager.getAll().map(createRoute);
     },
 
     /**


### PR DESCRIPTION
This was preventing global overrides to work properly.

Since `RouteManager.setAll` updates the `routes`, I need to get the `routes` through `RouteManager.getAll`.