### PR TITLE
fix(server): stringifying data when it's an integer

### DIFF
--- a/source/server.ts
+++ b/source/server.ts
@@ -129,6 +129,10 @@ export function createServer(options = {} as ServerOptions): Server {
       content = overrideContent(req, content);
     }
 
+    if (Number.isInteger(data)) {
+      content = content.toString();
+    }
+
     return content;
   }
 


### PR DESCRIPTION
This PR closes [#43](https://github.com/rhberro/the-fake-backend/issues/43).

**Description**
The content is stringified so it is not mistakenly mapped to the response code instead