### PR TITLE
Use route proxy as middleware

### DIFF
--- a/__mocks__/http-proxy-middleware.ts
+++ b/__mocks__/http-proxy-middleware.ts
@@ -1,1 +1,1 @@
-export default () => () => 'proxy';
+export const createProxyMiddleware = () => () => 'proxy';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,8 +2149,7 @@
     "@types/node": {
       "version": "13.13.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.39.tgz",
-      "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw==",
-      "dev": true
+      "integrity": "sha512-wct+WgRTTkBm2R3vbrFOqyZM5w0g+D8KnhstG9463CJBVC3UVZHMToge7iMBR1vDl/I+NWFHUeK9X+JcF0rWKw=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -4350,11 +4349,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-    },
     "exec-sh": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
@@ -4881,9 +4875,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -5485,14 +5479,30 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0.tgz",
-      "integrity": "sha512-dNJAk71nEJhPiAczQH9hGvE/MT9kEs+zn2Dh+Hi94PGZe1GluQirC7mw5rdREUtWx6qGS1Gu0bZd4qEAg+REgw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+      "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
       "requires": {
-        "http-proxy": "^1.17.0",
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.20",
         "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "@types/http-proxy": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.5.tgz",
+          "integrity": "sha512-GNkDE7bTv6Sf8JbV2GksknKOsk7OznNYHSdrtvPJXO0qJ9odZig6IZKUi5RFGi6d1bf6dgIAe4uXi3DBc7069Q==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "http-signature": {
@@ -14466,6 +14476,11 @@
         "ws": "^5.2.0"
       },
       "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
         "ws": {
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "fuzzy": "^0.1.3",
-    "http-proxy-middleware": "^0.20.0",
+    "http-proxy-middleware": "^1.0.6",
     "inquirer": "^7.1.0",
     "inquirer-autocomplete-prompt": "^1.0.2",
     "ramda": "^0.27.1"

--- a/source/interfaces/Proxy.ts
+++ b/source/interfaces/Proxy.ts
@@ -1,5 +1,7 @@
+import { RequestHandler } from 'http-proxy-middleware';
+
 export default interface Proxy {
   name: string;
   host: string;
-  proxy: Function;
+  proxy: RequestHandler;
 }

--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -22,7 +22,7 @@ describe('source/proxy.ts', () => {
     const proxies: ProxyProperties[] = [
       { name: 'First', host: 'firsthost.com' },
       { name: 'Second', host: 'secondhost.com' },
-      { name: 'Third', host: 'thirdhost.com' },
+      { name: 'Third', host: 'thirdhost.com', appendBasePath: false },
     ];
 
     beforeEach(() => {
@@ -162,6 +162,38 @@ describe('source/proxy.ts', () => {
         it('prompts and sets a null route proxy', async () => {
           await proxyManager.chooseRouteProxy();
           expect(routes[0].proxy).toBeNull();
+        });
+      });
+    });
+
+    describe('resolveRouteProxy', () => {
+      const proxy = {
+        name: 'Second',
+        host: 'secondhost.com',
+        proxy: () => 'proxy',
+      };
+
+      describe('when route has an active proxy', () => {
+        beforeEach(() => {
+          routes[0].proxy = proxy;
+        });
+
+        it('resolves to the route proxy', () => {
+          expect(proxyManager.resolveRouteProxy(routes[0])).toEqual(
+            proxy.proxy
+          );
+        });
+      });
+
+      describe('when server has an active proxy', () => {
+        beforeEach(() => {
+          proxyManager.toggleCurrent();
+        });
+
+        it('resolves to the server proxy', () => {
+          expect(proxyManager.resolveRouteProxy(routes[1])).toEqual(
+            expect.any(Function)
+          );
         });
       });
     });

--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -34,7 +34,7 @@ describe('source/proxy.ts', () => {
       const routeManager = new RouteManager();
       routeManager.setAll(routes);
 
-      proxyManager = new ProxyManager(proxies, routeManager);
+      proxyManager = new ProxyManager(routeManager, proxies);
     });
 
     describe('constructor', () => {

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -1,4 +1,4 @@
-import httpProxyMiddleware from 'http-proxy-middleware';
+import { createProxyMiddleware, RequestHandler } from 'http-proxy-middleware';
 
 import { Proxy, ProxyProperties, Route } from './interfaces';
 import { promptRoutePath, promptProxy } from './prompts';
@@ -19,7 +19,7 @@ function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
   return {
     host,
     name,
-    proxy: httpProxyMiddleware({
+    proxy: createProxyMiddleware({
       target: host,
       pathRewrite: (path) =>
         appendBasePath ? path : path.replace(basePath || '', ''),

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -138,4 +138,20 @@ export class ProxyManager {
 
     return route;
   }
+
+  /**
+   * Resolve the current proxy for a given route.
+   *
+   * @param route The route
+   * @return Resolved proxy
+   */
+  resolveRouteProxy(route: Route): RequestHandler | undefined {
+    const current = this.getCurrent();
+
+    if (route.proxy !== undefined) {
+      return route.proxy?.proxy;
+    }
+
+    return current?.proxy;
+  }
 }

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -36,13 +36,13 @@ export class ProxyManager {
   /**
    * Creates a new proxy manager.
    *
-   * @param proxies The proxies properties
    * @param routeManager An instance of route manager
+   * @param proxies The proxies properties
    * @param basePath The server basePath
    */
   constructor(
-    proxies: ProxyProperties[] = [],
     routeManager: RouteManager,
+    proxies: ProxyProperties[] = [],
     basePath?: string
   ) {
     this.routeManager = routeManager;

--- a/source/routes.spec.ts
+++ b/source/routes.spec.ts
@@ -106,6 +106,16 @@ describe('source/routes.ts', () => {
           expect(routeManager.getAll()).toHaveLength(0);
         });
       });
+
+      describe('findRouteByPath', () => {
+        beforeEach(() => {
+          routeManager.setAll(routes);
+        });
+
+        it('returns the route that matches the path', () => {
+          expect(routeManager.findRouteByPath('/users')).toEqual(routes[0]);
+        });
+      });
     });
 
     describe('when has global overrides', () => {

--- a/source/routes.ts
+++ b/source/routes.ts
@@ -130,4 +130,11 @@ export class RouteManager {
       ],
     });
   }
+
+  /**
+   * Find a route by path.
+   */
+  findRouteByPath(path: string) {
+    return this.routes.find((route) => route.path === path);
+  }
 }

--- a/source/routes.ts
+++ b/source/routes.ts
@@ -1,3 +1,4 @@
+import { propEq } from 'ramda';
 import { MethodType } from './enums';
 import htmlSummary from './html-summary';
 import { Route, Method, MethodOverride } from './interfaces';
@@ -135,6 +136,6 @@ export class RouteManager {
    * Find a route by path.
    */
   findRouteByPath(path: string) {
-    return this.routes.find((route) => route.path === path);
+    return this.routes.find(propEq('path', path));
   }
 }

--- a/source/server.ts
+++ b/source/server.ts
@@ -59,7 +59,7 @@ export function createServer(options = {} as ServerOptions): Server {
     if (route) {
       const proxy = proxyManager.resolveRouteProxy(route);
       if (proxy) {
-        return proxy?.(req, res, next);
+        return proxy(req, res, next);
       }
     }
 

--- a/source/server.ts
+++ b/source/server.ts
@@ -34,7 +34,7 @@ export function createServer(options = {} as ServerOptions): Server {
 
   const routeManager = new RouteManager(overrides);
   const overrideManager = new OverrideManager(routeManager);
-  const proxyManager = new ProxyManager(proxies, routeManager, basePath);
+  const proxyManager = new ProxyManager(routeManager, proxies, basePath);
   const throttlingManager = new ThrottlingManager(throttlings);
   const uiManager = new UIManager(
     proxyManager,

--- a/source/ui.spec.ts
+++ b/source/ui.spec.ts
@@ -55,7 +55,7 @@ describe('source/ui.ts', () => {
   describe('UIManager', () => {
     let uiManager: UIManager;
     const routeManager = new RouteManager();
-    const proxyManager = new ProxyManager(routeManager, []);
+    const proxyManager = new ProxyManager(routeManager);
     const throttlingManager = new ThrottlingManager();
     const overrideManager = new OverrideManager(routeManager);
 

--- a/source/ui.spec.ts
+++ b/source/ui.spec.ts
@@ -55,7 +55,7 @@ describe('source/ui.ts', () => {
   describe('UIManager', () => {
     let uiManager: UIManager;
     const routeManager = new RouteManager();
-    const proxyManager = new ProxyManager([], routeManager);
+    const proxyManager = new ProxyManager(routeManager, []);
     const throttlingManager = new ThrottlingManager();
     const overrideManager = new OverrideManager(routeManager);
 


### PR DESCRIPTION
Fixes #50.

This bug was due to `http-proxy-middleware` not being used as middleware.

This PR also updates `http-proxy-middleware` version.