### PR TITLE
Add support to proxy request handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,13 @@ The script above generates the following two endpoints.
 
 This property allows to proxy requests.
 
-| Property                 | Required | Default | Description                                     |
-| ------------------------ | -------- | ------- | ----------------------------------------------- |
-| proxies[].name           | yes      |         | The proxy name                                  |
-| proxies[].host           | yes      |         | The proxy host (e.g.: `http://api.dev.com/api`) |
-| proxies[].appendBasePath | No       | `false` | Whether `basePath` should be appended in target |
+| Property                 | Required | Default | Description                                                                                                                         |
+| ------------------------ | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| proxies[].name           | yes      |         | The proxy name                                                                                                                      |
+| proxies[].host           | yes      |         | The proxy host (e.g.: `http://api.dev.com/api`)                                                                                     |
+| proxies[].appendBasePath | No       | `false` | Whether `basePath` should be appended in target                                                                                     |
+| proxies[].onProxyReq     | No       |         | A proxy request handler to forward to [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#http-proxy-events)  |
+| proxies[].onProxyRes     | No       |         | A proxy response handler to forward to [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware#http-proxy-events) |
 
 #### Throttlings
 

--- a/source/interfaces/Proxy.ts
+++ b/source/interfaces/Proxy.ts
@@ -3,5 +3,5 @@ import { RequestHandler } from 'http-proxy-middleware';
 export default interface Proxy {
   name: string;
   host: string;
-  proxy: RequestHandler;
+  handler: RequestHandler;
 }

--- a/source/interfaces/ProxyProperties.ts
+++ b/source/interfaces/ProxyProperties.ts
@@ -1,10 +1,8 @@
-import { ClientRequest } from 'http';
-import Request from './Request';
-import Response from './Response';
+import { ProxyRequestHandler } from '../types';
 
 export default interface ProxyProperties {
   name: string;
   host: string;
   appendBasePath?: boolean;
-  onProxyReq?: (proxyReq: ClientRequest, req: Request, res: Response) => void;
+  onProxyReq?: ProxyRequestHandler;
 }

--- a/source/interfaces/ProxyProperties.ts
+++ b/source/interfaces/ProxyProperties.ts
@@ -1,5 +1,10 @@
+import { ClientRequest } from 'http';
+import Request from './Request';
+import Response from './Response';
+
 export default interface ProxyProperties {
   name: string;
   host: string;
   appendBasePath?: boolean;
+  onProxyReq?: (proxyReq: ClientRequest, req: Request, res: Response) => void;
 }

--- a/source/interfaces/ProxyProperties.ts
+++ b/source/interfaces/ProxyProperties.ts
@@ -1,8 +1,9 @@
-import { ProxyRequestHandler } from '../types';
+import { ProxyRequestHandler, ProxyResponseHandler } from '../types';
 
 export default interface ProxyProperties {
   name: string;
   host: string;
   appendBasePath?: boolean;
   onProxyReq?: ProxyRequestHandler;
+  onProxyRes?: ProxyResponseHandler;
 }

--- a/source/interfaces/ServerOptions.ts
+++ b/source/interfaces/ServerOptions.ts
@@ -2,12 +2,13 @@ import PaginationProperties from './PaginationProperties';
 import ProxyProperties from './ProxyProperties';
 import Throttling from './Throttling';
 import MethodOverride from './MethodOverride';
+import { RequestHandler } from 'express';
 
 export default interface ServerOptions {
   basePath?: string;
   docsRoute?: string;
   definitions?: TemplateStringsArray | string;
-  middlewares?: Array<any>;
+  middlewares?: Array<RequestHandler>;
   overrides?: Array<MethodOverride>;
   pagination?: PaginationProperties;
   proxies: Array<ProxyProperties>;

--- a/source/interfaces/index.ts
+++ b/source/interfaces/index.ts
@@ -2,7 +2,6 @@ export { default as InputListener } from './InputListener';
 export { default as Method } from './Method';
 export { default as MethodOverride } from './MethodOverride';
 export { default as MethodProperties } from './MethodProperties';
-export { default as Middleware } from './Middleware';
 export { default as Override } from './Override';
 export { default as Pagination } from './Pagination';
 export { default as PaginationProperties } from './PaginationProperties';

--- a/source/overrides.ts
+++ b/source/overrides.ts
@@ -1,5 +1,4 @@
 import {
-  both,
   complement,
   either,
   equals,
@@ -10,13 +9,7 @@ import {
   propOr,
   propSatisfies,
 } from 'ramda';
-import {
-  Method,
-  MethodOverride,
-  Route,
-  Override,
-  Middleware,
-} from './interfaces';
+import { Method, MethodOverride, Route, Override } from './interfaces';
 import {
   promptRoutePath,
   promptRouteMethodType,
@@ -29,6 +22,7 @@ import {
   formatMethodType,
   RouteManager,
 } from './routes';
+import { Middleware } from './types';
 
 const OVERRIDE_DEFAULT_OPTION = 'Default';
 

--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -82,7 +82,7 @@ describe('source/proxy.ts', () => {
         const proxy = {
           name: 'Second',
           host: 'secondhost.com',
-          proxy: () => 'proxy',
+          handler: () => 'proxy',
         };
 
         routes[0].proxy = proxy;

--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -45,15 +45,23 @@ describe('source/proxy.ts', () => {
     });
 
     describe('getAll', () => {
-      it('returns the proxies with an additional proxy property', () => {
+      it('returns the proxies with an additional handler property', () => {
         expect(proxyManager.getAll()).toEqual([
-          { name: 'First', host: 'firsthost.com', proxy: expect.any(Function) },
+          {
+            name: 'First',
+            host: 'firsthost.com',
+            handler: expect.any(Function),
+          },
           {
             name: 'Second',
             host: 'secondhost.com',
-            proxy: expect.any(Function),
+            handler: expect.any(Function),
           },
-          { name: 'Third', host: 'thirdhost.com', proxy: expect.any(Function) },
+          {
+            name: 'Third',
+            host: 'thirdhost.com',
+            handler: expect.any(Function),
+          },
         ]);
       });
     });
@@ -68,7 +76,7 @@ describe('source/proxy.ts', () => {
         expect(proxyManager.getCurrent()).toEqual({
           name: 'First',
           host: 'firsthost.com',
-          proxy: expect.any(Function),
+          handler: expect.any(Function),
         });
       });
     });
@@ -130,7 +138,7 @@ describe('source/proxy.ts', () => {
           expect(routes[0].proxy).toEqual({
             name: 'Second',
             host: 'secondhost.com',
-            proxy: expect.any(Function),
+            handler: expect.any(Function),
           });
         });
       });
@@ -148,7 +156,7 @@ describe('source/proxy.ts', () => {
           expect(routes[0].proxy).toEqual({
             name: 'First',
             host: 'firsthost.com',
-            proxy: expect.any(Function),
+            handler: expect.any(Function),
           });
         });
       });

--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -1,12 +1,13 @@
 import { mocked } from 'ts-jest/utils';
 import { getMockReq, getMockRes } from '@jest-mock/express';
 
-import { Middleware, ProxyProperties, Response, Route } from './interfaces';
+import { ProxyProperties, Response, Route } from './interfaces';
 
 import { ProxyManager } from './proxy';
 import { MethodType } from './enums';
 import { promptProxy } from './prompts';
 import { RouteManager } from './routes';
+import { Middleware } from './types';
 
 jest.mock('../source/prompts', () => ({
   promptProxy: jest.fn(),

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -2,9 +2,7 @@ import { createProxyMiddleware, RequestHandler } from 'http-proxy-middleware';
 import {
   both,
   complement,
-  compose,
   equals,
-  not,
   pathSatisfies,
   prop,
   propEq,

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -24,7 +24,7 @@ const PROXY_DEFAULT_OPTION = 'Local';
  * @return The proxy with the proxy middleware
  */
 function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
-  const { appendBasePath, name, host, onProxyReq } = proxy;
+  const { appendBasePath, name, host, onProxyReq, onProxyRes } = proxy;
 
   return {
     host,
@@ -35,6 +35,7 @@ function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
         appendBasePath ? path : path.replace(basePath || '', ''),
       changeOrigin: true,
       onProxyReq,
+      onProxyRes,
     }),
   };
 }

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -25,7 +25,7 @@ const PROXY_DEFAULT_OPTION = 'Local';
  * @return The proxy with the proxy middleware
  */
 function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
-  const { appendBasePath, name, host } = proxy;
+  const { appendBasePath, name, host, onProxyReq } = proxy;
 
   return {
     host,
@@ -35,6 +35,7 @@ function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
       pathRewrite: (path) =>
         appendBasePath ? path : path.replace(basePath || '', ''),
       changeOrigin: true,
+      onProxyReq,
     }),
   };
 }

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -9,9 +9,10 @@ import {
   propSatisfies,
 } from 'ramda';
 
-import { Middleware, Proxy, ProxyProperties, Route } from './interfaces';
+import { Proxy, ProxyProperties, Route } from './interfaces';
 import { promptRoutePath, promptProxy } from './prompts';
 import { getRoutesPaths, findRouteByUrl, RouteManager } from './routes';
+import { Middleware } from './types';
 
 const PROXY_DEFAULT_OPTION = 'Local';
 

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -30,7 +30,7 @@ function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
   return {
     host,
     name,
-    proxy: createProxyMiddleware({
+    handler: createProxyMiddleware({
       target: host,
       pathRewrite: (path) =>
         appendBasePath ? path : path.replace(basePath || '', ''),
@@ -85,19 +85,19 @@ export class ProxyManager {
   }
 
   /**
-   * Resolve the current proxy for a given route.
+   * Resolve the current proxy handler for a given route.
    *
    * @param route The route
-   * @return Resolved proxy
+   * @return Resolved proxy handler
    */
-  private resolveRouteProxy(route: Route): RequestHandler | undefined {
+  private resolveRouteProxyHandler(route: Route): RequestHandler | undefined {
     const current = this.getCurrent();
 
     if (route.proxy) {
-      return route.proxy.proxy;
+      return route.proxy.handler;
     }
 
-    return current?.proxy;
+    return current?.handler;
   }
 
   /**
@@ -176,11 +176,9 @@ export class ProxyManager {
     return (req, res, next) => {
       const { route } = res.locals;
 
-      if (route) {
-        const proxy = this.resolveRouteProxy(route);
-        if (proxy) {
-          return proxy(req, res, next);
-        }
+      const handler = this.resolveRouteProxyHandler(route);
+      if (handler) {
+        return handler(req, res, next);
       }
 
       next();

--- a/source/response/paginated.ts
+++ b/source/response/paginated.ts
@@ -1,9 +1,5 @@
-import {
-  ServerOptions,
-  Pagination,
-  PaginationProperties,
-  Middleware,
-} from '../interfaces';
+import { ServerOptions, Pagination, PaginationProperties } from '../interfaces';
+import { Middleware } from '../types';
 
 function resolvePaginationProperties(
   routePagination: PaginationProperties | boolean,

--- a/source/response/searchable.spec.ts
+++ b/source/response/searchable.spec.ts
@@ -1,7 +1,7 @@
-import searchRedact from './searchable';
+import { getMockReq, getMockRes } from '@jest-mock/express';
+
 import { Method, Response } from '../interfaces';
 import { MethodType } from '../enums';
-import { getMockReq, getMockRes } from '@jest-mock/express';
 import createSearchableMiddleware from './searchable';
 
 describe('source/response/searchable.ts', () => {

--- a/source/response/searchable.ts
+++ b/source/response/searchable.ts
@@ -1,4 +1,5 @@
-import { Search, Middleware } from '../interfaces';
+import { Search } from '../interfaces';
+import { Middleware } from '../types';
 
 function filterProperty(
   query: any,

--- a/source/routes.spec.ts
+++ b/source/routes.spec.ts
@@ -1,8 +1,9 @@
-import { RouteProperties, Method, Response, Middleware } from './interfaces';
-
-import { findRouteMethodByType, findRouteByUrl, RouteManager } from './routes';
-import { MethodType } from './enums';
 import { getMockReq, getMockRes } from '@jest-mock/express';
+
+import { MethodType } from './enums';
+import { RouteProperties, Method, Response } from './interfaces';
+import { findRouteMethodByType, findRouteByUrl, RouteManager } from './routes';
+import { Middleware } from './types';
 
 describe('source/routes.ts', () => {
   describe('findRouteByUrl', () => {

--- a/source/routes.ts
+++ b/source/routes.ts
@@ -185,11 +185,16 @@ export class RouteManager {
     return (req, res, next) => {
       const { path, method } = req;
       const routePath = path.replace(options.basePath || '', '');
-      const route = this.findRouteByPath(routePath);
-      const routeMethod = this.findRouteMethod(routePath, method);
 
-      res.locals.route = route;
-      res.locals.routeMethod = routeMethod;
+      try {
+        const route = this.findRouteByPath(routePath);
+        const routeMethod = this.findRouteMethod(routePath, method);
+
+        res.locals.route = route;
+        res.locals.routeMethod = routeMethod;
+      } catch (e) {
+        return res.status(404).send('Not found');
+      }
 
       next();
     };

--- a/source/routes.ts
+++ b/source/routes.ts
@@ -8,9 +8,8 @@ import {
   MethodOverride,
   Request,
   ServerOptions,
-  Middleware,
 } from './interfaces';
-import { MethodAttribute } from './types';
+import { MethodAttribute, Middleware } from './types';
 
 export function getRoutesPaths(routes: Route[]) {
   return routes.map(prop('path'));

--- a/source/server.ts
+++ b/source/server.ts
@@ -1,7 +1,6 @@
 import cors from 'cors';
-import express, { NextFunction } from 'express';
+import express from 'express';
 
-import { readFixtureSync } from './files';
 import { InputManager } from './input';
 import {
   Method,

--- a/source/throttling.spec.ts
+++ b/source/throttling.spec.ts
@@ -1,9 +1,9 @@
-import { Middleware, Response, Route, Throttling } from './interfaces';
 import { getMockReq, getMockRes } from '@jest-mock/express';
 
+import { Response, Route, Throttling } from './interfaces';
 import { ThrottlingManager } from './throttling';
 import { MethodType } from './enums';
-import { mocked } from 'ts-jest/utils';
+import { Middleware } from './types';
 
 jest.useFakeTimers();
 

--- a/source/throttling.ts
+++ b/source/throttling.ts
@@ -1,4 +1,5 @@
-import { Method, Middleware, Throttling } from './interfaces';
+import { Method, Throttling } from './interfaces';
+import { Middleware } from './types';
 
 export class ThrottlingManager {
   private currentThrottlingIndex: number | null;

--- a/source/types/Middleware.ts
+++ b/source/types/Middleware.ts
@@ -1,6 +1,5 @@
 import { NextFunction } from 'express';
-import Request from './Request';
-import Response from './Response';
+import { Request, Response } from '../interfaces';
 
 type Middleware<T = any> = (
   req: Request,

--- a/source/types/ProxyRequestHandler.ts
+++ b/source/types/ProxyRequestHandler.ts
@@ -1,4 +1,5 @@
 import { ClientRequest } from 'http';
+import { Request, Response } from '../interfaces';
 
 type ProxyRequestHandler = (
   proxyReq: ClientRequest,

--- a/source/types/ProxyRequestHandler.ts
+++ b/source/types/ProxyRequestHandler.ts
@@ -1,0 +1,9 @@
+import { ClientRequest } from 'http';
+
+type ProxyRequestHandler = (
+  proxyReq: ClientRequest,
+  req: Request,
+  res: Response
+) => void;
+
+export default ProxyRequestHandler;

--- a/source/types/ProxyResponseHandler.ts
+++ b/source/types/ProxyResponseHandler.ts
@@ -1,0 +1,10 @@
+import { IncomingMessage } from 'http';
+import { Request, Response } from '../interfaces';
+
+type ProxyResponseHandler = (
+  proxyRes: IncomingMessage,
+  req: Request,
+  res: Response
+) => void;
+
+export default ProxyResponseHandler;

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -1,4 +1,5 @@
 export { default as MethodAttribute } from './MethodAttribute';
 export { default as Middleware } from './Middleware';
 export { default as ProxyRequestHandler } from './ProxyRequestHandler';
+export { default as ProxyResponseHandler } from './ProxyResponseHandler';
 export { default as ResponseHeaders } from './ResponseHeaders';

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -1,3 +1,4 @@
 export { default as MethodAttribute } from './MethodAttribute';
+export { default as Middleware } from '../types/Middleware';
 export { default as ProxyRequestHandler } from './ProxyRequestHandler';
 export { default as ResponseHeaders } from './ResponseHeaders';

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -1,4 +1,4 @@
 export { default as MethodAttribute } from './MethodAttribute';
-export { default as Middleware } from '../types/Middleware';
+export { default as Middleware } from './Middleware';
 export { default as ProxyRequestHandler } from './ProxyRequestHandler';
 export { default as ResponseHeaders } from './ResponseHeaders';

--- a/source/types/index.ts
+++ b/source/types/index.ts
@@ -1,2 +1,3 @@
 export { default as MethodAttribute } from './MethodAttribute';
+export { default as ProxyRequestHandler } from './ProxyRequestHandler';
 export { default as ResponseHeaders } from './ResponseHeaders';

--- a/source/ui.spec.ts
+++ b/source/ui.spec.ts
@@ -107,7 +107,7 @@ describe('source/ui.ts', () => {
                 proxy: {
                   name: 'Second',
                   host: 'secondhost.com',
-                  proxy: () => 'proxy',
+                  handler: () => 'proxy',
                 },
               },
             ]);
@@ -125,7 +125,7 @@ describe('source/ui.ts', () => {
               (): Proxy => ({
                 name: 'Second',
                 host: 'secondhost.com',
-                proxy: () => 'proxy',
+                handler: () => 'proxy',
               })
             );
             getOverriddenProxyRoutes.mockImplementation(() => [

--- a/source/ui.ts
+++ b/source/ui.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import readline, { Interface as ReadLine } from 'readline';
 
-import { Middleware } from './interfaces';
+import { Middleware } from './types';
 import { OverrideManager } from './overrides';
 import { ProxyManager } from './proxy';
 import { ThrottlingManager } from './throttling';


### PR DESCRIPTION
This pull-request adds support to custom proxy request handlers by adding a `ProxyProperties.onProxyReq` attribute. The property name was chosen based on [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) signature.

It also adds a 404 Not Found handling to unknown routes, and it cuts the middleware chain for safety.

Last, but not least, it performs minor refactorings/adjustments:
* rename `Proxy.proxy` to `Proxy.handler`
* move `Middleware` from interfaces to types
* remove unused variables
* add missing tests for overrides middlewares