### PR TITLE
Fix dynamic route matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4519,6 +4519,11 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+        },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -12512,9 +12517,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+      "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "http-proxy-middleware": "^1.0.6",
     "inquirer": "^7.1.0",
     "inquirer-autocomplete-prompt": "^1.0.2",
+    "path-to-regexp": "^6.2.0",
     "ramda": "^0.27.1"
   },
   "devDependencies": {

--- a/source/routes.spec.ts
+++ b/source/routes.spec.ts
@@ -10,15 +10,23 @@ describe('source/routes.ts', () => {
     const routes: RouteProperties[] = [
       { path: '/users', methods: [{ type: MethodType.GET }] },
       { path: '/dogs', methods: [{ type: MethodType.GET }] },
+      { path: '/cats/:id', methods: [{ type: MethodType.GET }] },
     ];
 
     it('throws an error if path is not present', () => {
       expect(() => findRouteByUrl(routes, '/cats')).toThrowError();
     });
 
-    it('returns found routes with the given path', () => {
+    it('returns found route with the given path', () => {
       expect(findRouteByUrl(routes, '/dogs')).toEqual({
         path: '/dogs',
+        methods: [{ type: MethodType.GET }],
+      });
+    });
+
+    it('returns found parameterized route with the given path', () => {
+      expect(findRouteByUrl(routes, '/cats/123')).toEqual({
+        path: '/cats/:id',
         methods: [{ type: MethodType.GET }],
       });
     });

--- a/source/routes.ts
+++ b/source/routes.ts
@@ -1,4 +1,5 @@
 import { prop, propEq } from 'ramda';
+import { match } from 'path-to-regexp';
 import { MethodType } from './enums';
 import { readFixtureSync } from './files';
 import htmlSummary from './html-summary';
@@ -20,7 +21,11 @@ export function formatMethodType(methodType: string) {
 }
 
 export function findRouteByUrl(routes: Route[], url: string): Route {
-  const route = routes.find(propEq('path', url));
+  const route = routes.find(({ path }) => {
+    const routeMatch = match(path);
+
+    return routeMatch(url);
+  });
 
   if (route) {
     return route;


### PR DESCRIPTION
This PR fixes dynamic route matching.

This bug was introduced in #69 because it was comparing `req.path` with `routes[].path` to resolve a route in the `createResolvedRouteMiddleware`.

When the request has binding parameters (e.g. `/cats/:id`), the `req.path` (e.g. `/cats/123`) don't match.

As express middlewares don't expose access to the matched route, by design, we had to add an external library to perform route matching.