### PR TITLE
Fix dynamic route fixture

### DIFF
--- a/source/routes.spec.ts
+++ b/source/routes.spec.ts
@@ -164,7 +164,10 @@ describe('source/routes.ts', () => {
             response: routes[0].methods[0].data,
           };
 
-          middleware = routeManager.createRouteMethodResponseMiddleware();
+          middleware = routeManager.createRouteMethodResponseMiddleware({
+            proxies: [],
+            throttlings: [],
+          });
         });
 
         it('resolves the response of a given request', () => {

--- a/source/server.ts
+++ b/source/server.ts
@@ -55,7 +55,7 @@ export function createServer(options = {} as ServerOptions): Server {
     routeManager.createResolvedRouteMiddleware(options),
     proxyManager.createMiddleware(),
     overrideManager.createOverriddenRouteMethodMiddleware(),
-    routeManager.createRouteMethodResponseMiddleware(),
+    routeManager.createRouteMethodResponseMiddleware(options),
     createSearchableMiddleware(),
     createPaginatedMiddleware(options),
     overrideManager.createOverriddenContentMiddleware(),


### PR DESCRIPTION
This PR fixes dynamic route fixture matching when there is a fixture for a resolved parameter.

Example 1:
- request: `/cats/123`
- fixtures: [`cats/123.json`, `cats/:id.json`]
- expected fixture: `cats/123.json`
- returned fixture: `cats/:id.json`  :negative_squared_cross_mark: 

Example 2:
- request: `/cats/1234`
- fixtures: [`cats/123.json`, `cats/:id.json`]
- expected fixture: `cats/:id.json`
- returned fixture: `cats/:id.json` :heavy_check_mark:


This bug was introduced in #69.