### PR TITLE
Add global proxy middleware

### DIFF
--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -176,14 +176,14 @@ describe('source/proxy.ts', () => {
       });
     });
 
-    describe('createMiddleware', () => {
+    describe('createRouteMiddleware', () => {
       const mockedRequest = getMockReq();
       const mockedResponse = getMockRes().res as Response;
       const mockedNext = jest.fn();
       let middleware: Middleware;
 
       beforeEach(() => {
-        middleware = proxyManager.createMiddleware();
+        middleware = proxyManager.createRouteMiddleware();
       });
 
       it('resolves to the route proxy when route has an active proxy', () => {
@@ -198,14 +198,20 @@ describe('source/proxy.ts', () => {
         middleware(mockedRequest, mockedResponse, mockedNext);
         expect(mockedNext).toHaveBeenLastCalledWith(secondProxy.host);
       });
+    });
+
+    describe('createGlobalMiddleware', () => {
+      const mockedRequest = getMockReq();
+      const mockedResponse = getMockRes().res as Response;
+      const mockedNext = jest.fn();
+      let middleware: Middleware;
+
+      beforeEach(() => {
+        middleware = proxyManager.createGlobalMiddleware();
+      });
 
       it('resolves to the server proxy when server has an active proxy', () => {
         proxyManager.toggleCurrent();
-        mockedResponse.locals = {
-          route: routes[1],
-          routeMethod: routes[1].methods[0],
-          response: undefined,
-        };
 
         middleware(mockedRequest, mockedResponse, mockedNext);
         expect(mockedNext).toHaveBeenLastCalledWith(proxies[0].host);

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -92,11 +92,17 @@ export class ProxyManager {
    * @return Resolved proxy handler
    */
   private resolveRouteProxyHandler(route: Route): RequestHandler | undefined {
-    const current = this.getCurrent();
+    return route.proxy?.handler;
+  }
 
-    if (route.proxy) {
-      return route.proxy.handler;
-    }
+  /**
+   * Resolve the current global proxy handler.
+   *
+   * @param route The route
+   * @return Resolved proxy handler
+   */
+  private resolveGlobalProxyHandler(): RequestHandler | undefined {
+    const current = this.getCurrent();
 
     return current?.handler;
   }
@@ -171,13 +177,27 @@ export class ProxyManager {
   }
 
   /**
-   * Create a middleware that optionally proxy requests.
+   * Create a middleware that optionally proxy route requests.
    */
-  createMiddleware(): Middleware {
+  createRouteMiddleware(): Middleware {
     return (req, res, next) => {
       const { route } = res.locals;
 
       const handler = this.resolveRouteProxyHandler(route);
+      if (handler) {
+        return handler(req, res, next);
+      }
+
+      next();
+    };
+  }
+
+  /**
+   * Create a middleware that optionally proxy requests globally.
+   */
+  createGlobalMiddleware(): Middleware {
+    return (req, res, next) => {
+      const handler = this.resolveGlobalProxyHandler();
       if (handler) {
         return handler(req, res, next);
       }

--- a/source/server.ts
+++ b/source/server.ts
@@ -51,9 +51,10 @@ export function createServer(options = {} as ServerOptions): Server {
   expressServer.use(middlewares || cors());
 
   expressServer.use(
+    proxyManager.createGlobalMiddleware(),
     uiManager.createDrawRequestMiddleware(),
     routeManager.createResolvedRouteMiddleware(options),
-    proxyManager.createMiddleware(),
+    proxyManager.createRouteMiddleware(),
     overrideManager.createOverriddenRouteMethodMiddleware(),
     throttlingManager.createMiddleware()
   );


### PR DESCRIPTION
This PR creates a global proxy middleware and adds it to the top of the chain, so it will forward requests even if they aren't mapped in the server routes.

And then, the previous proxy middleware was specialized as route proxy middleware.