### PR TITLE
feat: allow to override any options from proxy object

### DIFF
--- a/source/interfaces/ProxyProperties.ts
+++ b/source/interfaces/ProxyProperties.ts
@@ -1,6 +1,7 @@
 import { ProxyRequestHandler, ProxyResponseHandler } from '../types';
+import { Options } from 'http-proxy-middleware';
 
-export default interface ProxyProperties {
+export default interface ProxyProperties extends Options {
   name: string;
   host: string;
   appendBasePath?: boolean;

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -30,6 +30,7 @@ function buildProxy(proxy: ProxyProperties, basePath?: string): Proxy {
     host,
     name,
     handler: createProxyMiddleware({
+      ...proxy,
       target: host,
       pathRewrite: (path) =>
         appendBasePath ? path : path.replace(basePath || '', ''),


### PR DESCRIPTION
This PR allows to the user to override `Options`, which is going to be provided to `http-proxy-middleware`.

It would allow to implement custom behavior on any feature through any value provided by `http-proxy-middleware`.