### PR TITLE
File storage: persisting changes over restarts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4977,6 +4977,12 @@
         "universalify": "^0.1.0"
       }
     },
+    "fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://nexus.dc.ifood.com.br/repository/ifood-npm/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -7874,6 +7880,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memfs": {
+      "version": "3.2.2",
+      "resolved": "https://nexus.dc.ifood.com.br/repository/ifood-npm/memfs/-/memfs-3.2.2.tgz",
+      "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+      "dev": true,
+      "requires": {
+        "fs-monkey": "1.0.3"
+      }
     },
     "meow": {
       "version": "8.1.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "cz-conventional-changelog": "^3.3.0",
     "husky": "^4.2.5",
     "jest": "^26.6.3",
+    "memfs": "^3.2.2",
     "mock-fs": "^4.12.0",
     "prettier": "2.0.4",
     "pretty-quick": "^2.0.1",

--- a/source/interfaces/ServerOptions.ts
+++ b/source/interfaces/ServerOptions.ts
@@ -3,6 +3,7 @@ import ProxyProperties from './ProxyProperties';
 import Throttling from './Throttling';
 import MethodOverride from './MethodOverride';
 import { RequestHandler } from 'express';
+import { FileStorageOptions } from '../storage';
 
 export default interface ServerOptions {
   basePath?: string;
@@ -13,4 +14,5 @@ export default interface ServerOptions {
   pagination?: PaginationProperties;
   proxies: Array<ProxyProperties>;
   throttlings: Array<Throttling>;
+  fileStorageOptions?: FileStorageOptions;
 }

--- a/source/overrides.ts
+++ b/source/overrides.ts
@@ -77,13 +77,14 @@ export class OverrideManager {
   ) {}
 
   applyExternalOverrides() {
-    if (!this.fileStorage?.options.enabled) return;
+    if (!this.fileStorage?.options.enabled || !this.fileStorage.isInitialized())
+      return;
 
-    if (this.fileStorage.isInitialized() && this.fileStorage.isEmpty()) {
+    if (this.fileStorage.isEmpty()) {
       this.fileStorage?.setItem(FILE_STORAGE_KEY, this.getAllSelected());
     } else {
       const persistedOverrides = this.fileStorage.getItem<Override[]>(
-        'overrides'
+        FILE_STORAGE_KEY
       );
 
       persistedOverrides?.forEach((override) => {

--- a/source/overrides.ts
+++ b/source/overrides.ts
@@ -22,6 +22,7 @@ import {
   formatMethodType,
   RouteManager,
 } from './routes';
+import { FileStorage } from './storage';
 import { Middleware } from './types';
 
 const OVERRIDE_DEFAULT_OPTION = 'Default';
@@ -62,16 +63,41 @@ function findSelectedMethodOverride(method: Method) {
   return method.overrides?.find(propSatisfies(equals(true), 'selected'));
 }
 
-export class OverrideManager {
-  private routeManager: RouteManager;
+const FILE_STORAGE_KEY = 'overrides';
 
+export class OverrideManager {
   /**
    * Creates a new override manager.
    *
    * @param routeManager An instance of route manager
    */
-  constructor(routeManager: RouteManager) {
-    this.routeManager = routeManager;
+  constructor(
+    private routeManager: RouteManager,
+    private fileStorage?: FileStorage<typeof FILE_STORAGE_KEY>
+  ) {}
+
+  applyExternalOverrides() {
+    if (!this.fileStorage?.options.enabled) return;
+
+    if (this.fileStorage.isInitialized() && this.fileStorage.isEmpty()) {
+      this.fileStorage?.setItem(FILE_STORAGE_KEY, this.getAllSelected());
+    } else {
+      const persistedOverrides = this.fileStorage.getItem<Override[]>(
+        'overrides'
+      );
+
+      persistedOverrides?.forEach((override) => {
+        const overridableRoutes = this.getAll();
+        const url = override.routePath;
+        const route = findRouteByUrl(overridableRoutes, url);
+        const type = override.methodType;
+        const overrides = getMethodOverridesByType(route, type.toLowerCase());
+        const name = override.name;
+        overrides.forEach((override) => {
+          override.selected = override.name === name;
+        });
+      });
+    }
   }
 
   /**
@@ -127,6 +153,8 @@ export class OverrideManager {
     overrides.forEach((override) => {
       override.selected = override.name === name;
     });
+
+    this.fileStorage?.setItem('overrides', this.getAllSelected());
 
     return { routePath: url, methodType: type, name };
   }

--- a/source/storage.spec.ts
+++ b/source/storage.spec.ts
@@ -1,0 +1,63 @@
+import { FileStorage } from './storage';
+import { fs as inMemoryFileSystem, vol } from 'memfs';
+
+describe('FileStorage', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('throws an error when file is invalid', () => {
+    inMemoryFileSystem.writeFileSync('/.storage', 'abc');
+    createFileStorage();
+    expect(() => {
+      createFileStorage().getItem('foo');
+    }).toThrow('Invalid file storage content');
+  });
+
+  it('throws an error when path is missing', () => {
+    expect(() => {
+      new FileStorage({ enabled: true });
+    }).toThrow('FileStorage path option is missing');
+  });
+
+  it('does not initializes store if disabled', () => {
+    expect(() => {
+      new FileStorage({ enabled: false, path: '/.storage' });
+      inMemoryFileSystem.readFileSync('/.storage', 'utf-8');
+    }).toThrowError("ENOENT: no such file or directory, open '/.storage'");
+  });
+
+  it('properly creates an empty storage when the storage file does not exist', () => {
+    createFileStorage();
+    expect(inMemoryFileSystem.readFileSync('/.storage', 'utf-8')).toEqual('{}');
+  });
+
+  it('properly creates a storage with the content of a existing file', () => {
+    inMemoryFileSystem.writeFileSync(
+      '/.storage',
+      '{ "foo": { "key": "value" } }'
+    );
+    createFileStorage();
+    expect(createFileStorage().getItem('foo')).toEqual({ key: 'value' });
+  });
+
+  it('sets and gets item from storage', () => {
+    expect(() => {
+      createFileStorage().setItem('foo', { key: 'value' });
+    }).not.toThrow();
+
+    expect(createFileStorage().getItem('foo')).toEqual({ key: 'value' });
+  });
+
+  it('gets an unexisting item from storage', () => {
+    expect(createFileStorage().getItem('foo')).toEqual(undefined);
+  });
+});
+
+function createFileStorage() {
+  return new FileStorage<'foo'>({
+    enabled: true,
+    path: '/.storage',
+    fs: inMemoryFileSystem as any,
+  });
+}

--- a/source/storage.ts
+++ b/source/storage.ts
@@ -1,0 +1,100 @@
+import * as fs from 'fs';
+
+type PartialFileSystem = {
+  readFileSync(path: string, options: string): string;
+  writeFileSync(path: string, data: string): void;
+};
+
+export interface FileStorageOptions {
+  enabled: boolean;
+  path?: string;
+  fs?: PartialFileSystem;
+}
+
+const EMPTY_STORAGE = {};
+
+const DEFAULT_OPTIONS = { enabled: false };
+
+export class FileStorage<TKeys extends string> {
+  private fs: PartialFileSystem;
+
+  constructor(public options: FileStorageOptions = DEFAULT_OPTIONS) {
+    this.fs = this.options.fs ?? fs;
+
+    if (options.enabled) {
+      this.initializeStorage();
+    }
+  }
+
+  public isEmpty() {
+    return Object.keys(this.getStorage()).length === 0;
+  }
+
+  public isInitialized() {
+    try {
+      if (!this.options.enabled || !this.options.path) return false;
+      this.fs.readFileSync(this.options.path, 'utf-8');
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  public getItem<TData = unknown>(key: TKeys): TData | undefined {
+    if (!this.isInitialized()) return;
+
+    const storage = this.getStorage<TData>();
+    return storage[key];
+  }
+
+  public setItem<TData = Record<string, unknown>>(key: TKeys, data: TData) {
+    if (!this.isInitialized()) return;
+
+    const storage = this.getStorage();
+    storage[key] = data;
+
+    if (this.options.path) {
+      this.persist(storage);
+    }
+  }
+
+  public clear() {
+    this.persist(EMPTY_STORAGE);
+  }
+
+  private persist<TData = unknown>(data: Record<string, TData>) {
+    if (this.options.path) {
+      this.fs.writeFileSync(this.options.path, JSON.stringify(data, null, 2));
+    }
+  }
+
+  private getStorage<TData = unknown>(): Record<TKeys, TData> {
+    const fileContent = this.getSerializedStorage();
+    try {
+      return JSON.parse(fileContent);
+    } catch (e) {
+      throw new Error('Invalid file storage content');
+    }
+  }
+
+  private initializeStorage(): void {
+    if (!this.options.path) {
+      throw new Error('FileStorage path option is missing');
+    }
+
+    if (!this.isInitialized()) {
+      this.persist(EMPTY_STORAGE);
+    }
+  }
+
+  private getSerializedStorage(): string {
+    try {
+      if (!this.options.path) return '{}';
+      return this.fs.readFileSync(this.options.path, 'utf-8');
+    } catch (e) {
+      if (e.code !== 'ENOENT') throw e;
+      this.initializeStorage();
+      return this.getSerializedStorage();
+    }
+  }
+}

--- a/source/ui.ts
+++ b/source/ui.ts
@@ -6,6 +6,7 @@ import { OverrideManager } from './overrides';
 import { ProxyManager } from './proxy';
 import { ThrottlingManager } from './throttling';
 import { formatMethodType } from './routes';
+import { FileStorage } from './storage';
 
 function formatEndpoint(routePath: string, methodType: string) {
   return `${formatMethodType(methodType)} ${routePath}`;
@@ -13,9 +14,6 @@ function formatEndpoint(routePath: string, methodType: string) {
 
 export class UIManager {
   private display: ReadLine;
-  private proxyManager: ProxyManager;
-  private overrideManager: OverrideManager;
-  private throttlingManager: ThrottlingManager;
 
   /**
    * Write a text to the user screen.
@@ -131,6 +129,15 @@ export class UIManager {
       `- ${chalk.bold.white('p')} to toggle the connection to an endpoint`
     );
     this.paragraph(`- ${chalk.bold.white('q')} to stop and quit the service`);
+
+    if (this.fileStorage?.options.enabled) {
+      this.paragraph(
+        `- ${chalk.bold.white(
+          'x'
+        )} to reset file storage permanently (restart to apply changes)`
+      );
+    }
+
     this.linebreak();
   }
 
@@ -143,9 +150,10 @@ export class UIManager {
    * @return The UI manager
    */
   constructor(
-    proxyManager: ProxyManager,
-    throttlingManager: ThrottlingManager,
-    overrideManager: OverrideManager
+    public proxyManager: ProxyManager,
+    public throttlingManager: ThrottlingManager,
+    public overrideManager: OverrideManager,
+    private fileStorage?: FileStorage<string>
   ) {
     this.display = readline.createInterface({
       input: process.stdin,


### PR DESCRIPTION
### :point_right: **Issue**

After applying overrides or changing connection type on terminal, these changes are **lost** after restarting the application. This is valid for every available setting (`Connection`, `Connection overrides`, `Throttling`, and `Overrides`). 

Note that `Overrides` is slight different, because you can change the `selected` flag directly on code and have our settings persisted. But that isn't ideal yet, given that you may lost your changes if you don't commit them -- but commiting these doesn't feel right because some of them are just personal preferences according to a scenario you may want to test...

### :point_right: **Solution**

Introducing the `FileStorage`, which is able to persit data into a file. This persistence is useful in a way any service can use it to load and persist data. This service is written to support writing data using `keys` to isolate contexts. The API is similar to browser's LocalStorage.

To reset the configuration to the initial state, you could press `x` on terminal to reset the file to the initial state. Also you need to restart the server in order to have your initial state applied.

To enabled the current `FileStorage` implementation, you need to add `fileStorageOptions.enabled = true` on the server options. Also you need to set the path where your storage will be persisted on your disk. We also suggest to include the file storage on `.gitignore`.

### :point_right: **Caveat**

Right now, the only service which is using `FileStorage` is `OverrideManager`, which exposes a method called `applyExternalOverrides`. That method has two responsibilities:
- Properly initializes the `FileStorage` (using a key called `overrides`) with the current overrides selected.
- Populate the `OverrideManager` data with content from the `FileStorage` using the previous key (`overrides`).

Besides `OverrideManager` be the only service with is using `FileStorage`, any other service could do the same.

### :point_right: **Dependencies**

`memfs` - Used on tests to validate filesystem operations without creating and reading files on disk - those operations happen in memory.

### :point_right: **Side changes**

- `mockOverridePrompts`- Abstraction over prompts mocks when typing the `Overrides` inputs.
-  Use typescript syntax sugar to auto assign constructor parameters to class attributes.