### PR TITLE
chore: add sourcemap to build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ export default {
   output: {
     dir: 'build',
     format: 'cjs',
+    sourcemap: true,
   },
   plugins: [
     cleaner({ targets: ['build'] }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "removeComments": true,
     "rootDir": "source/",
     "strict": true,
-    "target": "es5"
+    "target": "es5",
+    "sourceMap": true
   },
   "include": ["source"]
 }


### PR DESCRIPTION
Add support sourcemap file to build, it allows better debugging on host applications.