### PR TITLE
fix: skip server proxy when route proxy is overriden to default

### DIFF
--- a/source/proxy.spec.ts
+++ b/source/proxy.spec.ts
@@ -216,6 +216,19 @@ describe('source/proxy.ts', () => {
         middleware(mockedRequest, mockedResponse, mockedNext);
         expect(mockedNext).toHaveBeenLastCalledWith(proxies[0].host);
       });
+
+      it('skips the server proxy when the route proxy is overriden to default', () => {
+        proxyManager.toggleCurrent();
+        routes[0].proxy = null;
+        mockedResponse.locals = {
+          route: routes[0],
+          routeMethod: routes[0].methods[0],
+          response: undefined,
+        };
+
+        middleware(mockedRequest, mockedResponse, mockedNext);
+        expect(mockedNext).toHaveBeenLastCalledWith();
+      });
     });
   });
 });

--- a/source/proxy.ts
+++ b/source/proxy.ts
@@ -104,6 +104,16 @@ export class ProxyManager {
   }
 
   /**
+   * Checks if the proxy is overridden to default for a given route.
+   *
+   * @param route The route
+   * @returns {boolean}
+   */
+   private isRouteProxyOverridenToDefault(route: Route): boolean {
+    return route.proxy === null;
+  }
+
+  /**
    * Resolve the current global proxy handler.
    *
    * @param route The route
@@ -206,6 +216,11 @@ export class ProxyManager {
   createGlobalMiddleware(): Middleware {
     return (req, res, next) => {
       const handler = this.resolveGlobalProxyHandler();
+
+      if (res.locals?.route && this.isRouteProxyOverridenToDefault(res.locals.route)) {
+        return next();
+      }
+
       if (handler) {
         return handler(req, res, next);
       }

--- a/source/server.ts
+++ b/source/server.ts
@@ -55,12 +55,12 @@ export function createServer(options = {} as ServerOptions): Server {
   expressServer.use(middlewares || cors());
 
   expressServer.use(
-    proxyManager.createGlobalMiddleware(),
     uiManager.createDrawRequestMiddleware(),
     routeManager.createResolvedRouteMiddleware(options),
     proxyManager.createRouteMiddleware(),
     overrideManager.createOverriddenRouteMethodMiddleware(),
-    throttlingManager.createMiddleware()
+    throttlingManager.createMiddleware(),
+    proxyManager.createGlobalMiddleware()
   );
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When the server proxy is different from "Local" and the route proxy is "Local", then when you request for the overwritten route, it still tries to hit the server proxy.

Fixes #106 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

In the fix branch, replaces the current example by [this example](https://github.com/eltongarbin/fake-backend-example/blob/main/index.js) and verifies that the overridden route proxy is working when the server proxy is different.

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/3240432/155052862-c5229c35-1bae-47e2-b5d8-95ffb0607c5a.mp4

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed