### PR TITLE
fix(config): fixing the npm version inside package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "engines": {
     "node": ">=12.14.1",
-    "npm": ">=8"
+    "npm": ">=6.13.4"
   },
   "author": {
     "name": "Rafael Henrique Berro",


### PR DESCRIPTION
Downgrading the minimum required NPM version from `8` to `6.13.4`, requiring a NPM version `8` also makes the minimum required Node version to be `16+` which is not needed for the whole project.

A huge thanks for @fsmaia who reported the problem with a great explanation of it.