### PR TITLE
chore: allow body to be read as json

### DIFF
--- a/source/server.spec.ts
+++ b/source/server.spec.ts
@@ -43,9 +43,9 @@ const expressServer = {
 };
 
 jest.mock('express', () => {
-  return () => {
-    return expressServer;
-  };
+  const fn = () => expressServer;
+  fn.json = jest.fn();
+  return fn;
 });
 
 describe('source/server.ts', () => {

--- a/source/server.ts
+++ b/source/server.ts
@@ -52,6 +52,7 @@ export function createServer(options = {} as ServerOptions): Server {
     graphqlManager.applyMiddlewareTo(expressServer);
   }
 
+  expressServer.use(express.json());
   expressServer.use(middlewares || cors());
 
   expressServer.use(


### PR DESCRIPTION
Without `.json()`, we are not able to read `req.body` easily.