### PR TITLE
fix: Route registration fails on Windows due to backslash path separators

### DIFF
--- a/source/server.ts
+++ b/source/server.ts
@@ -18,7 +18,7 @@ import { resolveMethodAttribute, RouteManager } from './routes';
 import { ThrottlingManager } from './throttling';
 import { UIManager } from './ui';
 import { GraphQLManager } from './graphql';
-import { join } from 'path';
+import { posix } from 'path';
 import { FileStorage } from './storage';
 
 export function createServer(options = {} as ServerOptions): Server {
@@ -96,7 +96,7 @@ export function createServer(options = {} as ServerOptions): Server {
     const { type } = method;
 
     expressServer[type](
-      join(basePath, path),
+      posix.join(basePath, path),
       routeManager.createRouteMethodResponseMiddleware(options),
       createSearchableRouteMiddleware(),
       createPaginatedRouteMiddleware(options),


### PR DESCRIPTION
## Problem

Routes were not being registered correctly on Windows, causing all requests to return `404 Not Found` errors, even though:
- The routes were passed correctly to `server.routes()`
- The middleware logging showed requests were being received
- CORS headers were working correctly
- The same code worked perfectly on macOS

In `source/server.ts`, the code was using Node.js `path.join()` to construct Express route paths. On Windows, `path.join()` uses backslashes (`\`) as path separators, which caused Express to register routes with backslash paths (e.g., `\test`), but incoming HTTP requests use forward slashes (e.g., `/test`). Since these don't match, Express returned 404 for all routes.

## Solution

Changed from `path.join()` to `path.posix.join()`, which always uses forward slashes regardless of the operating system.

## Changes

- **`source/server.ts`**: Changed import from `{ join }` to `{ posix }` and updated the route path construction to use `posix.join()` instead of `join()`

## Testing

Verified on Windows 10/11:
- Routes now return `200 OK` instead of `404 Not Found`
- All existing functionality (throttling, overrides, proxies) continues to work
- macOS compatibility maintained (no regression)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)